### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/test/packet_transformer.dart
+++ b/test/packet_transformer.dart
@@ -82,6 +82,7 @@ void testFile(IO.File testFile, StreamController<Result> resultStream,
   Result res = new Result();
   testFile
       .openRead()
+      .cast<List<int>>()
       .transform(new ESL.PacketTransformer())
       .listen((ESL.Packet packet) => res.packetCount++, onDone: () {
     res.runtime = new DateTime.now().difference(start);


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900